### PR TITLE
Feature/encrypt existing data

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'label' => 'TAO encryption',
     'description' => 'TAO encryption',
     'license' => 'GPL-2.0',
-    'version' => '0.3.1',
+    'version' => '0.4.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=17.7.0',

--- a/scripts/tools/SetupEncryptedFileSystem.php
+++ b/scripts/tools/SetupEncryptedFileSystem.php
@@ -22,7 +22,9 @@ namespace oat\taoEncryption\scripts\tools;
 
 use oat\oatbox\extension\script\ScriptAction;
 use common_report_Report as Report;
+use oat\oatbox\filesystem\FileSystem;
 use oat\oatbox\filesystem\FileSystemService;
+use oat\taoEncryption\Service\EncryptionServiceInterface;
 use oat\taoEncryption\Service\FileSystem\EncryptionFlyWrapper;
 
 /**
@@ -39,16 +41,18 @@ use oat\taoEncryption\Service\FileSystem\EncryptionFlyWrapper;
  * Available arguments:
  *
  * Required Arguments:
- *   -f fileSystemId, --fileSystemId fileSystemId
- *     The File System ID as it appears in the TAO File System configuration
- *   -e encryptionServiceId, --encryptionServiceId encryptionServiceId
- *     The ID of the EncryptionService to be used for data encryption/decryption
+ *  -f fileSystemId, --fileSystemId fileSystemId
+ *    The File System ID as it appears in the TAO File System configuration
+ *  -e encryptionServiceId, --encryptionServiceId encryptionServiceId
+ *    The ID of the EncryptionService to be used for data encryption/decryption
  *
  * Optional Arguments:
- *   -k keyProviderServiceId, --keyProviderServiceId keyProviderServiceId
- *     The ID of the KeyProviderService to be used for key provisioning
- *   -h help, --help help
- *     Prints a help statement
+ *  -k keyProviderServiceId, --keyProviderServiceId keyProviderServiceId
+ *    The ID of the KeyProviderService to be used for key provisioning
+ *  -d, --encryptData
+ *    Encrypt existing data in the target File System (works only with not already encrypted File Systems)
+ *  -h help, --help help
+ *    Prints a help statement
  *
  * @package oat\taoEncryption\scripts\tools
  */
@@ -93,6 +97,12 @@ class SetupEncryptedFileSystem extends ScriptAction
                 'longPrefix' => 'keyProviderServiceId',
                 'required' => false,
                 'description' => 'The ID of the KeyProviderService to be used for key provisioning'
+            ],
+            'encryptData' => [
+                'prefix' => 'd',
+                'longPrefix' => 'encryptData',
+                'flag' => true,
+                'description' => 'Encrypt existing data in the target File System (works only with not already encrypted File Systems)'
             ]
         ];
     }
@@ -158,6 +168,7 @@ class SetupEncryptedFileSystem extends ScriptAction
         /** @var FileSystemService $fileSystemService */
         $fileSystemService = $this->getServiceLocator()->get(FileSystemService::SERVICE_ID);
         $fileSystemServiceOptions = $fileSystemService->getOption(FileSystemService::OPTION_ADAPTERS);
+        $alreadyEncrypted = false;
 
         if (isset($fileSystemServiceOptions[$fileSystemId])) {
             if ($fileSystemServiceOptions[$fileSystemId]['class'] === 'Local') {
@@ -171,6 +182,8 @@ class SetupEncryptedFileSystem extends ScriptAction
                     new Report(Report::TYPE_SUCCESS, "Contents of File System '${fileSystemId}' will now be encrypted with EncryptionService '${encryptionServiceId}'.")
                 );
             } elseif ($fileSystemServiceOptions[$fileSystemId]['class'] === EncryptionFlyWrapper::class) {
+                $alreadyEncrypted = true;
+
                 $fileSystemServiceOptions[$fileSystemId]['options']['encryptionServiceId'] = $encryptionServiceId;
                 $this->getServiceManager()->register(FileSystemService::SERVICE_ID, $fileSystemService);
 
@@ -180,6 +193,35 @@ class SetupEncryptedFileSystem extends ScriptAction
             } else {
                 return new Report(Report::TYPE_ERROR, "Only Local File Systems can be encrypted for the moment. File System '${fileSystemId}' is not.");
             }
+
+            // Let's check whether we have to encrypt existing data.
+            if ($this->hasOption('encryptData') && $alreadyEncrypted === false) {
+                /** @var FileSystem $fileSystem */
+                $fileSystem = $fileSystemService->getFileSystem($fileSystemId);
+                $contents = $fileSystem->listContents('', true);
+
+                /** @var EncryptionServiceInterface $encryptionService */
+                $encryptionService = $this->getServiceLocator()->get($encryptionServiceId);
+
+                foreach ($contents as $content) {
+                    if ($content['type'] === 'file') {
+                        $path = $content['path'];
+                        $data = $fileSystem->read($path);
+
+                        if ($content === false) {
+                            $report->add(new Report(Report::TYPE_WARNING, "File at '${fileSystemId}/${path}' could not be read for encryption."));
+                        } else {
+                            $update = $fileSystem->update($path, $encryptionService->encrypt($data));
+                            if ($update === true) {
+                                $report->add(new Report(Report::TYPE_INFO, "File at '${fileSystemId}/${path}' encrypted."));
+                            } else {
+                                $report->add(new Report(Report::TYPE_INFO, "File at '${fileSystemId}/${path}' could not be encrypted."));
+                            }
+                        }
+                    }
+                }
+            }
+
         } else {
             return new Report(
                 Report::TYPE_ERROR,

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -26,6 +26,6 @@ class Updater extends common_ext_ExtensionUpdater
 {
     public function update($initialVersion)
     {
-        $this->skip('0.1.0', '0.3.1');
+        $this->skip('0.1.0', '0.4.0');
     }
 }


### PR DESCRIPTION
This PR adds a `-d` flag to the `SetupEncryptedFileSystem` enabling a DevOps to encrypt the existing data present in the target file system. This will be required to encrypt already installed PCI components, as the encryption file system setup will happen after regular installation.

Example usage:

```shell
sudo -u www-data php index.php "oat\taoEncryption\scripts\tools\SetupEncryptedFileSystem" -f portableElementStorage -e taoEncryption/symmetricEncryptionService -d
```