### PR TITLE
delete variable after decrypted

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'TAO encryption',
     'description' => 'TAO encryption',
     'license' => 'GPL-2.0',
-    'version' => '1.2.1',
+    'version' => '1.2.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=17.7.0',

--- a/model/Service/Result/DecryptResultService.php
+++ b/model/Service/Result/DecryptResultService.php
@@ -158,11 +158,15 @@ class DecryptResultService extends ConfigurableService implements DecryptResult
             );
 
             foreach ($itemsTestsRefs as $ref) {
-                $variableStoreService->save(
+                $status = $variableStoreService->save(
                     $deliveryResultIdentifier,
                     $this->getResultRow($ref),
                     $resultStorage
                 );
+
+                if ($status) {
+                    $this->deleteVariable($ref);
+                }
             }
 
             $this->deleteRelatedDelivery($resultId);
@@ -289,6 +293,19 @@ class DecryptResultService extends ConfigurableService implements DecryptResult
     protected function deleteItemsTestsRefs($resultId)
     {
         return $this->getDeliveryResultVarsRefsModel()->deleteRefs($resultId);
+    }
+
+    /**
+     * @param $reference
+     * @return bool
+     * @throws \Exception
+     */
+    protected function deleteVariable($reference)
+    {
+        /** @var SyncEncryptedResultService $encryptedStorage */
+        $encryptedStorage = $this->getServiceLocator()->get(SyncEncryptedResultService::SERVICE_ID);
+
+        return $encryptedStorage->getPersistence()->del($reference);
     }
 
     /**

--- a/model/Service/Result/DecryptResultService.php
+++ b/model/Service/Result/DecryptResultService.php
@@ -182,6 +182,8 @@ class DecryptResultService extends ConfigurableService implements DecryptResult
         } catch (EmptyContentException $exception) {
             $resultsDecrypted[] = $resultId;
             $report->add(Report::createInfo('Result decrypted FAILED:'. $resultId . ' '. $exception->getMessage()));
+        } catch (\Exception $exception) {
+            $report->add(Report::createFailure('Result decrypted FAILED:'. $resultId . ' '. $exception->getMessage()));
         }
 
         return $report;

--- a/model/Service/Result/DecryptResultService.php
+++ b/model/Service/Result/DecryptResultService.php
@@ -49,6 +49,8 @@ class DecryptResultService extends ConfigurableService implements DecryptResult
 
     const OPTION_STORE_VARIABLE_SERVICE = 'storeVariableService';
 
+    const OPTION_REMOVE_VARIABLE_AFTER_DECRYPT = 'removeVariableAfterDecrypt';
+
     const PREFIX_DELIVERY_EXECUTION = EncryptResultService::PREFIX_DELIVERY_EXECUTION;
 
     const PREFIX_TEST_TAKER = EncryptResultService::PREFIX_TEST_TAKER;
@@ -164,7 +166,7 @@ class DecryptResultService extends ConfigurableService implements DecryptResult
                     $resultStorage
                 );
 
-                if ($status) {
+                if ($status && $this->isDeleteAfterDecryptEnabled()) {
                     $this->deleteVariable($ref);
                 }
             }
@@ -180,8 +182,6 @@ class DecryptResultService extends ConfigurableService implements DecryptResult
         } catch (EmptyContentException $exception) {
             $resultsDecrypted[] = $resultId;
             $report->add(Report::createInfo('Result decrypted FAILED:'. $resultId . ' '. $exception->getMessage()));
-        } catch (\Exception $exception) {
-            $report->add(Report::createFailure('Result decrypted FAILED:'. $resultId . ' '. $exception->getMessage()));
         }
 
         return $report;
@@ -241,6 +241,7 @@ class DecryptResultService extends ConfigurableService implements DecryptResult
 
     /**
      * @param $resultId
+     * @return bool
      * @throws \Exception
      */
     protected function deleteRelatedTestTaker($resultId)
@@ -305,7 +306,7 @@ class DecryptResultService extends ConfigurableService implements DecryptResult
         /** @var SyncEncryptedResultService $encryptedStorage */
         $encryptedStorage = $this->getServiceLocator()->get(SyncEncryptedResultService::SERVICE_ID);
 
-        return $encryptedStorage->getPersistence()->del($reference);
+        return $encryptedStorage->deleteVariable($reference);
     }
 
     /**
@@ -480,5 +481,13 @@ class DecryptResultService extends ConfigurableService implements DecryptResult
         }
 
         return $service;
+    }
+
+    /**
+     * @return bool|mixed
+     */
+    protected function isDeleteAfterDecryptEnabled()
+    {
+        return (bool)$this->getOption(static::OPTION_REMOVE_VARIABLE_AFTER_DECRYPT);
     }
 }

--- a/model/Service/Result/SyncEncryptedResultService.php
+++ b/model/Service/Result/SyncEncryptedResultService.php
@@ -149,6 +149,16 @@ class SyncEncryptedResultService extends ResultService
     }
 
     /**
+     * @param $reference
+     * @return bool
+     * @throws \Exception
+     */
+    public function deleteVariable($reference)
+    {
+        return $this->getPersistence()->del($reference);
+    }
+
+        /**
      * Get variables of a delivery execution
      *
      * @param $deliveryId
@@ -172,7 +182,7 @@ class SyncEncryptedResultService extends ResultService
      * @throws \Exception
      * @return common_persistence_KeyValuePersistence
      */
-    public function getPersistence()
+    protected function getPersistence()
     {
         if (is_null($this->persistence)){
             $persistenceId = $this->getOption(self::OPTION_PERSISTENCE);

--- a/model/Service/Result/SyncEncryptedResultService.php
+++ b/model/Service/Result/SyncEncryptedResultService.php
@@ -172,7 +172,7 @@ class SyncEncryptedResultService extends ResultService
      * @throws \Exception
      * @return common_persistence_KeyValuePersistence
      */
-    protected function getPersistence()
+    public function getPersistence()
     {
         if (is_null($this->persistence)){
             $persistenceId = $this->getOption(self::OPTION_PERSISTENCE);

--- a/scripts/install/RegisterDecryptResultStorage.php
+++ b/scripts/install/RegisterDecryptResultStorage.php
@@ -63,6 +63,7 @@ class RegisterDecryptResultStorage extends InstallAction
             DecryptResultService::OPTION_ENCRYPTION_SERVICE => EncryptionAsymmetricService::SERVICE_ID,
             DecryptResultService::OPTION_USER_ID_CLIENT_TO_USER_ID_CENTRAL => DummyMapper::SERVICE_ID,
             DecryptResultService::OPTION_STORE_VARIABLE_SERVICE => StoreVariableService::SERVICE_ID,
+            DecryptResultService::OPTION_REMOVE_VARIABLE_AFTER_DECRYPT => false,
         ]);
 
         $this->registerService(DecryptResultService::SERVICE_ID, $decrypt);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -149,6 +149,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.2.0');
         }
 
-        $this->skip('1.2.0', '1.2.1');
+        $this->skip('1.2.0', '1.2.2');
     }
 }

--- a/test/Service/Result/SyncEncryptedResultServiceTest.php
+++ b/test/Service/Result/SyncEncryptedResultServiceTest.php
@@ -79,6 +79,16 @@ class SyncEncryptedResultServiceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @throws \Exception
+     */
+    public function testDeleteVariable()
+    {
+        $service = $this->getService();
+
+        $this->assertTrue($service->deleteVariable('some ref'));
+    }
+
+    /**
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
     protected function mockResource()


### PR DESCRIPTION
We need to clear the storage after the decrypt of variable was done with success. This is an configurable option in case it's required, by default it's false.