### PR TITLE
vecatch DuplicateVariableException during result importing

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,12 +34,12 @@ return array(
     'label' => 'TAO encryption',
     'description' => 'TAO encryption',
     'license' => 'GPL-2.0',
-    'version' => '2.0.1',
+    'version' => '3.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=17.7.0',
         'generis' => '>=7.11.0',
-        'taoResultServer' => '>=6.2.0',
+        'taoResultServer' => '>=9.3.0',
         'taoSync' => '>=4.0.0',
         'taoProctoring' => '>=12.3.0',
         'taoTestCenter' => '>=4.1.0'

--- a/model/Service/Result/DecryptResultService.php
+++ b/model/Service/Result/DecryptResultService.php
@@ -35,6 +35,7 @@ use oat\taoResultServer\models\classes\implementation\ResultServerService;
 use oat\taoResultServer\models\Entity\ItemVariableStorable;
 use oat\taoResultServer\models\Entity\TestVariableStorable;
 use \common_report_Report as Report;
+use oat\taoResultServer\models\Exceptions\DuplicateVariableException;
 use oat\taoSync\model\TestSession\SyncTestSessionServiceInterface;
 
 class DecryptResultService extends ConfigurableService implements DecryptResult
@@ -158,11 +159,18 @@ class DecryptResultService extends ConfigurableService implements DecryptResult
             );
 
             foreach ($itemsTestsRefs as $ref) {
-                $variableStoreService->save(
-                    $deliveryResultIdentifier,
-                    $this->getResultRow($ref),
-                    $resultStorage
-                );
+                try {
+                    $variableStoreService->save(
+                        $deliveryResultIdentifier,
+                        $this->getResultRow($ref),
+                        $resultStorage
+                    );
+                } catch (DuplicateVariableException $e) {
+                    $this->logInfo(sprintf(
+                        'Variable for result `%s` already exists. Synchronisation of that variable was skipped.',
+                        $deliveryResultIdentifier
+                    ));
+                }
             }
 
             $this->deleteRelatedDelivery($resultId);

--- a/model/Service/Result/DecryptResultService.php
+++ b/model/Service/Result/DecryptResultService.php
@@ -167,7 +167,7 @@ class DecryptResultService extends ConfigurableService implements DecryptResult
                     );
                 } catch (DuplicateVariableException $e) {
                     $this->logInfo(sprintf(
-                        'Variable for result `%s` already exists. Synchronisation of that variable was skipped.',
+                        'Variable for result `%s` already exists. Decryption of that variable was skipped.',
                         $deliveryResultIdentifier
                     ));
                 }

--- a/model/Service/Result/StoreVariableService.php
+++ b/model/Service/Result/StoreVariableService.php
@@ -25,6 +25,7 @@ use oat\oatbox\service\ConfigurableService;
 use oat\taoResultServer\models\Entity\ItemVariableStorable;
 use oat\taoResultServer\models\Entity\TestVariableStorable;
 use oat\taoResultServer\models\Entity\VariableStorable;
+use oat\taoResultServer\models\Exceptions\DuplicateVariableException;
 use taoResultServer_models_classes_WritableResultStorage;
 
 class StoreVariableService extends ConfigurableService implements StoreVariableServiceInterface
@@ -34,6 +35,7 @@ class StoreVariableService extends ConfigurableService implements StoreVariableS
      * @param VariableStorable $resultRow
      * @param taoResultServer_models_classes_WritableResultStorage $resultStorage
      * @return bool
+     * @throws DuplicateVariableException
      */
     public function save($deliveryResultIdentifier, VariableStorable $resultRow, taoResultServer_models_classes_WritableResultStorage $resultStorage)
     {

--- a/model/Service/Result/StoreVariableServiceInterface.php
+++ b/model/Service/Result/StoreVariableServiceInterface.php
@@ -21,6 +21,7 @@
 namespace oat\taoEncryption\Service\Result;
 
 use oat\taoResultServer\models\Entity\VariableStorable;
+use oat\taoResultServer\models\Exceptions\DuplicateVariableException;
 use taoResultServer_models_classes_WritableResultStorage;
 
 interface StoreVariableServiceInterface
@@ -31,6 +32,7 @@ interface StoreVariableServiceInterface
      * @param string $deliveryResultIdentifier
      * @param VariableStorable $variableStorable
      * @param taoResultServer_models_classes_WritableResultStorage $storage
+     * @throws DuplicateVariableException
      * @return bool
      */
     public function save($deliveryResultIdentifier, VariableStorable $variableStorable,taoResultServer_models_classes_WritableResultStorage $storage);

--- a/model/Service/Result/SyncEncryptedResultService.php
+++ b/model/Service/Result/SyncEncryptedResultService.php
@@ -138,9 +138,11 @@ class SyncEncryptedResultService extends ResultService
         foreach ($resultsOfDeliveryMapper as $deliveryId => $resultsIds){
             $oldResults = $this->getDeliveryResultsModel()->getResultsReferences($deliveryId);
 
+            $resultsReferences = array_merge($oldResults, $resultsIds);
+
             $this->getDeliveryResultsModel()->setResultsReferences(
                 $deliveryId,
-                array_merge($oldResults, $resultsIds)
+                array_unique($resultsReferences)
             );
 
             foreach ($resultsIds as $resultId) {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -149,6 +149,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.2.0');
         }
 
-        $this->skip('1.2.0', '2.0.1');
+        $this->skip('1.2.0', '3.0.0');
     }
 }


### PR DESCRIPTION
The purpose is to avoid duplicates of result variables in result storage after synchronization.
In case if `DuplicateVariableException` is thrown during storing variable than appropriate message will be logged and that variable will be skipped.

depends on: https://github.com/oat-sa/extension-tao-outcomerds/pull/93