### PR TITLE
Feature/tao 8664/export results

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,13 +34,13 @@ return array(
     'label' => 'TAO encryption',
     'description' => 'TAO encryption',
     'license' => 'GPL-2.0',
-    'version' => '2.0.1',
+    'version' => '2.0.1.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=17.7.0',
         'generis' => '>=7.11.0',
         'taoResultServer' => '>=6.2.0',
-        'taoSync' => '>=4.0.0',
+        'taoSync' => '>=6.5.4.1',
         'taoProctoring' => '>=12.3.0',
         'taoTestCenter' => '>=4.1.0'
     ),

--- a/model/Service/Result/SyncEncryptedResultDataFormatter.php
+++ b/model/Service/Result/SyncEncryptedResultDataFormatter.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\taoEncryption\Service\Result;
+
+use common_persistence_KeyValuePersistence;
+use common_persistence_KvDriver;
+use oat\taoResultServer\models\Entity\ItemVariableStorable;
+use oat\taoResultServer\models\Entity\TestVariableStorable;
+use oat\taoSync\model\Result\SyncResultDataFormatter;
+
+class SyncEncryptedResultDataFormatter extends SyncResultDataFormatter
+{
+    const OPTION_PERSISTENCE = 'persistence';
+
+    /** @var  common_persistence_KvDriver*/
+    private $persistence;
+
+    /** @var DeliveryResultVarsRefsModel */
+    private $deliveryResultVarsRefs;
+
+    /**
+     * Get variables of a delivery execution
+     *
+     * @param $deliveryId
+     * @param $deliveryExecutionId
+     * @return array
+     * @throws \Exception
+     */
+    protected function getDeliveryExecutionVariables($deliveryId, $deliveryExecutionId)
+    {
+        $refs = $this->getDeliveryResultVarsRefsModel()->getResultsVariablesRefs($deliveryExecutionId);
+
+        $resultRows = [];
+        foreach ($refs as $ref) {
+            $resultRows[$ref] = $this->getResultRow($ref);
+        }
+
+        return $resultRows;
+    }
+
+    /**
+     * @return DeliveryResultVarsRefsModel
+     * @throws \Exception
+     */
+    protected function getDeliveryResultVarsRefsModel()
+    {
+        if (is_null($this->deliveryResultVarsRefs)){
+            $this->deliveryResultVarsRefs = new DeliveryResultVarsRefsModel($this->getPersistence());
+        }
+
+        return $this->deliveryResultVarsRefs;
+    }
+
+    /**
+     * @throws \Exception
+     * @return common_persistence_KeyValuePersistence
+     */
+    protected function getPersistence()
+    {
+        if (is_null($this->persistence)){
+            $persistenceId = $this->getOption(self::OPTION_PERSISTENCE);
+            $persistence = $this->getServiceLocator()->get(\common_persistence_Manager::SERVICE_ID)->getPersistenceById($persistenceId);
+
+            if (!$persistence instanceof common_persistence_KeyValuePersistence) {
+                throw new \Exception('Only common_persistence_KeyValuePersistence supported');
+            }
+
+            $this->persistence = $persistence;
+        }
+
+        return $this->persistence;
+    }
+
+    /**
+     * @param $ref
+     * @return bool|DecryptResultService|ItemVariableStorable|TestVariableStorable
+     * @throws \Exception
+     */
+    protected function getResultRow($ref)
+    {
+        return $this->getPersistence()->get($ref);
+    }
+}

--- a/model/Service/Result/SyncEncryptedResultService.php
+++ b/model/Service/Result/SyncEncryptedResultService.php
@@ -27,8 +27,6 @@ use oat\tao\model\taskQueue\QueueDispatcher;
 use oat\taoEncryption\Service\EncryptionServiceInterface;
 use oat\taoEncryption\Service\Mapper\MapperClientUserIdToCentralUserIdInterface;
 use oat\taoEncryption\Task\DecryptResultTask;
-use oat\taoResultServer\models\Entity\ItemVariableStorable;
-use oat\taoResultServer\models\Entity\TestVariableStorable;
 use oat\taoSync\model\ResultService;
 use Psr\Log\LogLevel;
 
@@ -154,26 +152,6 @@ class SyncEncryptedResultService extends ResultService
     }
 
     /**
-     * Get variables of a delivery execution
-     *
-     * @param $deliveryId
-     * @param $deliveryExecutionId
-     * @return array
-     * @throws \Exception
-     */
-    protected function getDeliveryExecutionVariables($deliveryId, $deliveryExecutionId)
-    {
-        $refs = $this->getDeliveryResultVarsRefsModel()->getResultsVariablesRefs($deliveryExecutionId);
-        $resultRows = [];
-
-        foreach ($refs as $ref) {
-            $resultRows[$ref] = $this->getResultRow($ref);
-        }
-
-        return $resultRows;
-    }
-
-    /**
      * @throws \Exception
      * @return common_persistence_KeyValuePersistence
      */
@@ -217,16 +195,6 @@ class SyncEncryptedResultService extends ResultService
         }
 
         return $this->deliveryResultVarsRefs;
-    }
-
-    /**
-     * @param $ref
-     * @return bool|DecryptResultService|ItemVariableStorable|TestVariableStorable
-     * @throws \Exception
-     */
-    protected function getResultRow($ref)
-    {
-        return $this->getPersistence()->get($ref);
     }
 
     /**

--- a/scripts/tools/SetupEncryptedSyncResult.php
+++ b/scripts/tools/SetupEncryptedSyncResult.php
@@ -25,8 +25,10 @@ use oat\oatbox\extension\InstallAction;
 use oat\taoEncryption\Service\EncryptionAsymmetricService;
 use oat\taoEncryption\Service\KeyProvider\AsymmetricKeyPairProviderService;
 use oat\taoEncryption\Service\Mapper\DummyMapper;
+use oat\taoEncryption\Service\Result\SyncEncryptedResultDataFormatter;
 use oat\taoEncryption\Service\Result\SyncEncryptedResultService;
 use oat\taoSync\model\event\SynchronisationStart;
+use oat\taoSync\model\Result\SyncResultDataFormatter;
 use oat\taoSync\model\ResultService;
 use common_report_Report as Report;
 
@@ -74,10 +76,20 @@ class SetupEncryptedSyncResult extends InstallAction
         $this->registerService(SyncEncryptedResultService::SERVICE_ID, $encrypted);
 
         $report->add(Report::createSuccess('SyncEncryptedResultService successfully registered.'));
+
+        /** @var SyncResultDataFormatter $formatter */
+        $dataFormatter = $this->getServiceLocator()->get(SyncResultDataFormatter::SERVICE_ID);
+        $options = $dataFormatter->getOptions();
+
+        $encryptedDataFormatter = new SyncEncryptedResultDataFormatter(array_merge([
+            SyncEncryptedResultDataFormatter::OPTION_PERSISTENCE => 'encryptedResults'
+        ], $options));
+        $this->registerService(SyncEncryptedResultDataFormatter::SERVICE_ID, $encryptedDataFormatter);
+
+        $report->add(Report::createSuccess('SyncEncryptedResultDataFormatter successfully registered.'));
         $report->add(Report::createSuccess($this->setupSynchronizationListener()));
 
         return $report;
-
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -40,6 +40,8 @@ use oat\taoEncryption\Service\KeyProvider\FileKeyProviderService;
 use oat\taoEncryption\Service\KeyProvider\SimpleKeyProviderService;
 use oat\taoEncryption\Service\User\EncryptedUserFactoryService;
 use oat\taoEncryption\scripts\install\RegisterTestSessionSyncMapper;
+use oat\taoSync\model\Result\SyncResultDataFormatter;
+use oat\taoSync\model\ResultService;
 use oat\taoSync\model\TestSession\SyncTestSessionServiceInterface;
 use oat\taoTestCenter\model\event\ProctorCreatedEvent;
 
@@ -150,6 +152,23 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.2.0');
         }
 
-        $this->skip('1.2.0', '3.1.0');
+        $this->skip('1.2.0', '3.0.0');
+
+        if ($this->isVersion('3.0.0')) {
+            $service = $this->getServiceManager()->get(ResultService::SERVICE_ID);
+            // register 'SyncEncryptedResultDataFormatter' if 'SetupEncryptedSyncResult' script was already executed
+            if (is_object($service) && $service instanceof SyncEncryptedResultService) {
+                /** @var SyncResultDataFormatter $formatter */
+                $dataFormatter = $this->getServiceManager()->get(SyncResultDataFormatter::SERVICE_ID);
+                $options = $dataFormatter->getOptions();
+
+                $encryptedDataFormatter = new SyncEncryptedResultDataFormatter(array_merge([
+                    SyncEncryptedResultDataFormatter::OPTION_PERSISTENCE => 'encryptedResults'
+                ], $options));
+                $this->getServiceManager()->register(SyncEncryptedResultDataFormatter::SERVICE_ID, $encryptedDataFormatter);
+            }
+
+            $this->setVersion('3.1.0');
+        }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -31,6 +31,7 @@ use oat\taoEncryption\scripts\tools\SetupDecryptDeliveryLogFormatterService;
 use oat\taoEncryption\Service\Mapper\DummyMapper;
 use oat\taoEncryption\Service\Result\DecryptResultService;
 use oat\taoEncryption\Service\Result\StoreVariableService;
+use oat\taoEncryption\Service\Result\SyncEncryptedResultDataFormatter;
 use oat\taoEncryption\Service\Result\SyncEncryptedResultService;
 use oat\taoEncryption\Service\Algorithm\AlgorithmSymmetricService;
 use oat\taoEncryption\Service\TestSession\EncryptSyncTestSessionService;
@@ -149,6 +150,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.2.0');
         }
 
-        $this->skip('1.2.0', '2.0.1');
+        $this->skip('1.2.0', '2.0.1.1');
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8664

This refactoring enables the reuse of delivery execution selection for result export. Current result synchronization should work the same.
If you already have `taoEncryption` installed please run `php index.php 'oat\taoEncryption\scripts\tools\SetupEncryptedSyncResult'` again.

Dependent PR:  https://github.com/oat-sa/extension-tao-sync/pull/150