### PR TITLE
Feature/tao 8853/export encrypted assembly

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'TAO encryption',
     'description' => 'TAO encryption',
     'license' => 'GPL-2.0',
-    'version' => '3.1.0',
+    'version' => '3.2.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=17.7.0',

--- a/manifest.php
+++ b/manifest.php
@@ -42,7 +42,8 @@ return array(
         'taoResultServer' => '>=9.3.0',
         'taoSync' => '>=6.6.0',
         'taoProctoring' => '>=12.3.0',
-        'taoTestCenter' => '>=4.1.0'
+        'taoTestCenter' => '>=4.1.0',
+        'taoDeliveryRdf' => '>=8.3.0.1'
     ),
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#EncryptionRole',
     'acl' => array(

--- a/model/Service/DeliveryAssembly/EncryptedAssemblerFactory.php
+++ b/model/Service/DeliveryAssembly/EncryptedAssemblerFactory.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoEncryption\Service\DeliveryAssembly;
+
+use oat\oatbox\service\ConfigurableService;
+use oat\taoDeliveryRdf\model\AssemblerServiceInterface;
+use oat\taoEncryption\Service\EncryptionAwareInterface;
+use Zend\ServiceManager\ServiceLocatorAwareTrait;
+
+class EncryptedAssemblerFactory extends ConfigurableService
+{
+    use ServiceLocatorAwareTrait;
+
+    /**
+     * @return AssemblerServiceInterface|EncryptionAwareInterface
+     */
+    public function create()
+    {
+        $assembler = $this->getServiceLocator()->get(AssemblerServiceInterface::SERVICE_ID);
+        $assemblerOptions = $assembler->getOptions();
+
+        $encryptedAssembler = new EncryptedAssemblerService($assemblerOptions);
+        $encryptedAssembler->setServiceLocator($this->getServiceLocator());
+
+        return $encryptedAssembler;
+    }
+}

--- a/model/Service/DeliveryAssembly/EncryptedAssemblerService.php
+++ b/model/Service/DeliveryAssembly/EncryptedAssemblerService.php
@@ -78,12 +78,12 @@ class EncryptedAssemblerService extends AssemblerService implements EncryptionAw
     }
 
     /**
-     * @return EncryptionAwareInterface|EncryptionServiceInterface
+     * @return EncryptionServiceInterface
      * @throws AssemblyExportFailedException
      */
     public function getEncryptionService()
     {
-        if (!$this->encryptionService instanceof EncryptionAwareInterface) {
+        if (!$this->encryptionService instanceof EncryptionServiceInterface) {
             throw new AssemblyExportFailedException('Encryption service is not set up.');
         }
 

--- a/model/Service/DeliveryAssembly/EncryptedAssemblerService.php
+++ b/model/Service/DeliveryAssembly/EncryptedAssemblerService.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoEncryption\Service\DeliveryAssembly;
+
+use tao_models_classes_service_StorageDirectory;
+use oat\taoDeliveryRdf\model\export\AssemblyExportFailedException;
+use oat\taoDeliveryRdf\model\import\AssemblerService;
+use oat\taoEncryption\Service\EncryptionAwareInterface;
+use oat\taoEncryption\Service\EncryptionServiceInterface;
+use Psr\Http\Message\StreamInterface;
+
+class EncryptedAssemblerService extends AssemblerService implements EncryptionAwareInterface
+{
+    /**
+     * @var EncryptionServiceInterface
+     */
+    private $encryptionService;
+
+    /**
+     * @param tao_models_classes_service_StorageDirectory $directory
+     * @param string $file
+     * @return StreamInterface|resource
+     * @throws AssemblyExportFailedException
+     */
+    protected function getFileSource(tao_models_classes_service_StorageDirectory $directory,$file)
+    {
+        $stream = parent::getFileSource($directory,$file);
+        if ($directory->isPublic()) {
+            return $stream;
+        }
+
+        return $this->encryptStream($stream);
+    }
+
+    /**
+     * TODO: switch to another encryption library which supports stream encryption and encrypt stream.
+     *
+     * @param StreamInterface $stream
+     * @return resource|StreamInterface
+     * @throws AssemblyExportFailedException
+     */
+    private function encryptStream(StreamInterface $stream)
+    {
+        $encryptionService = $this->getEncryptionService();
+
+        $cont = $stream->getContents();
+        $contents = $encryptionService->encrypt($cont);
+        $fp = fopen('php://temp','r+');
+        fwrite($fp, $contents);
+        rewind($fp);
+
+        return $fp;
+    }
+
+    /**
+     * @param EncryptionServiceInterface $encryptionService
+     */
+    public function setEncryptionService(EncryptionServiceInterface $encryptionService)
+    {
+        $this->encryptionService = $encryptionService;
+    }
+
+    /**
+     * @return EncryptionAwareInterface|EncryptionServiceInterface
+     * @throws AssemblyExportFailedException
+     */
+    public function getEncryptionService()
+    {
+        if (!$this->encryptionService instanceof EncryptionAwareInterface) {
+            throw new AssemblyExportFailedException('Encryption service is not set up.');
+        }
+
+        return $this->encryptionService;
+    }
+}

--- a/model/Service/DeliveryAssembly/EncryptedAssemblerService.php
+++ b/model/Service/DeliveryAssembly/EncryptedAssemblerService.php
@@ -41,7 +41,7 @@ class EncryptedAssemblerService extends AssemblerService implements EncryptionAw
      */
     protected function getFileSource(tao_models_classes_service_StorageDirectory $directory,$file)
     {
-        $stream = parent::getFileSource($directory,$file);
+        $stream = parent::getFileSource($directory, $file);
         if ($directory->isPublic()) {
             return $stream;
         }

--- a/model/Service/EncryptionAwareInterface.php
+++ b/model/Service/EncryptionAwareInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoEncryption\Service;
+
+interface EncryptionAwareInterface
+{
+    /**
+     * @param EncryptionServiceInterface $encryptionService
+     * @return void
+     */
+    public function setEncryptionService(EncryptionServiceInterface $encryptionService);
+}

--- a/model/Service/EncryptionServiceFactory.php
+++ b/model/Service/EncryptionServiceFactory.php
@@ -46,7 +46,6 @@ class EncryptionServiceFactory
         $encryptionService->setAlgorithm($algorithmService);
         $encryptionService->setKeyProvider($keyProvider);
 
-
         return $encryptionService;
     }
 }

--- a/model/Service/EncryptionServiceFactory.php
+++ b/model/Service/EncryptionServiceFactory.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoEncryption\Service;
+
+use oat\taoEncryption\Model\AlgorithmFactory;
+use oat\taoEncryption\Model\Symmetric\Symmetric;
+use oat\taoEncryption\Service\Algorithm\AlgorithmSymmetricService;
+use oat\taoEncryption\Service\KeyProvider\SimpleKeyProviderService;
+
+class EncryptionServiceFactory
+{
+    /**
+     * @param string $algorithmName
+     * @param string $key
+     *
+     * @return EncryptionSymmetricService
+     * @throws \Exception
+     */
+    public function createSymmetricService($algorithmName, $key)
+    {
+        $algorithmService = new AlgorithmSymmetricService([]);
+        $algorithm =new Symmetric(AlgorithmFactory::create($algorithmName));
+        $algorithmService->setAlgorithm($algorithm);
+
+        $keyProvider = new SimpleKeyProviderService();
+        $keyProvider->setKey($key);
+
+        $encryptionService = new EncryptionSymmetricService();
+        $encryptionService->setAlgorithm($algorithmService);
+        $encryptionService->setKeyProvider($keyProvider);
+
+
+        return $encryptionService;
+    }
+}

--- a/scripts/tools/DeliveryAssembly/ExportEncryptedAssembly.php
+++ b/scripts/tools/DeliveryAssembly/ExportEncryptedAssembly.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoEncryption\scripts\tools\DeliveryAssembly;
+
+use common_report_Report as Report;
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\extension\script\ScriptAction;
+use oat\taoDeliveryRdf\model\AssemblerServiceInterface;
+use oat\taoEncryption\Service\DeliveryAssembly\EncryptedAssemblerFactory;
+use oat\taoEncryption\Service\EncryptionAwareInterface;
+use oat\taoEncryption\Service\EncryptionServiceFactory;
+use oat\taoEncryption\Service\EncryptionSymmetricService;
+
+class ExportEncryptedAssembly extends ScriptAction
+{
+    use OntologyAwareTrait;
+
+    const OPTION_DELIVERY_URI = 'delivery-uri';
+
+    const OPTION_OUTPUT = 'output';
+
+    const OPTION_ENCRYPTION_ALGORITHM = 'encryption-algorithm';
+
+    const OPTION_ENCRYPTION_KEY = 'encryption-key';
+
+    /**
+     * @var Report
+     */
+    private $report;
+
+    /**
+     * @return string
+     */
+    protected function provideDescription()
+    {
+        return 'Exports delivery assembly package with encrypted private files.';
+    }
+
+    /**
+     * @return array
+     */
+    protected function provideOptions()
+    {
+        return [
+            self::OPTION_DELIVERY_URI => [
+                'prefix' => 'uri',
+                'required' => true,
+                'longPrefix' => self::OPTION_DELIVERY_URI,
+                'description' => 'Delivery URI',
+            ],
+            self::OPTION_ENCRYPTION_ALGORITHM => [
+                'prefix' => 'alg',
+                'longPrefix' => self::OPTION_ENCRYPTION_ALGORITHM,
+                'description' => 'Encryption algorithm',
+                'defaultValue' => 'AES'
+            ],
+            self::OPTION_ENCRYPTION_KEY => [
+                'prefix' => 'key',
+                'required' => true,
+                'longPrefix' => self::OPTION_ENCRYPTION_KEY,
+                'description' => 'Encryption key',
+            ],
+            self::OPTION_OUTPUT => [
+                'prefix' => 'out',
+                'longPrefix' => self::OPTION_OUTPUT,
+                'description' => 'Destination file path',
+            ]
+        ];
+    }
+
+    /**
+     * @return Report
+     */
+    protected function run()
+    {
+        $this->report = Report::createInfo('Delivery export started');
+
+        try {
+            $deliveryUri = $this->getOption(self::OPTION_DELIVERY_URI);
+            $this->report->add(Report::createInfo('Export delivery ' . $deliveryUri));
+            $encryptionService = $this->getEncryptionService(
+                $this->getOption(self::OPTION_ENCRYPTION_ALGORITHM),
+                $this->getOption(self::OPTION_ENCRYPTION_KEY)
+            );
+
+            $assembler = $this->getAssemblerService();
+            $assembler->setEncryptionService($encryptionService);
+
+            $delivery = $this->getResource($deliveryUri);
+
+            $exportedAssemblyPath = $assembler->exportCompiledDelivery($delivery);
+
+            if ($this->hasOption(self::OPTION_OUTPUT)) {
+                \tao_helpers_File::move($exportedAssemblyPath, $this->getOption(self::OPTION_OUTPUT));
+                $exportedAssemblyPath = $this->getOption(self::OPTION_OUTPUT);
+            }
+
+            $this->report->add(Report::createSuccess(sprintf("Delivery assembly '%s' exported to %s", $delivery->getLabel(), $exportedAssemblyPath)));
+        } catch (\Exception $e) {
+            $this->report->add(Report::createFailure("Export failed: " . $e->getMessage()));
+        }
+
+        return $this->report;
+    }
+
+    /**
+     * @return array
+     */
+    protected function provideUsage()
+    {
+        return [
+            'prefix' => 'h',
+            'longPrefix' => 'help',
+            'description' => 'Prints a help statement'
+        ];
+    }
+
+    /**
+     * @return AssemblerServiceInterface|EncryptionAwareInterface
+     */
+    private function getAssemblerService()
+    {
+        $factory = new EncryptedAssemblerFactory();
+        $this->propagate($factory);
+
+        return $factory->create();
+    }
+
+    /**
+     * @param $algorithmName
+     * @param $key
+     * @return EncryptionSymmetricService
+     * @throws \Exception
+     */
+    private function getEncryptionService($algorithmName, $key)
+    {
+        $encryptionServiceFactory = new EncryptionServiceFactory();
+
+        return $encryptionServiceFactory->createSymmetricService($algorithmName, $key);
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -171,6 +171,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('3.1.0');
         }
 
-        $this->skip('3.1.', '3.2.0');
+        $this->skip('3.1.0', '3.2.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -170,5 +170,7 @@ class Updater extends common_ext_ExtensionUpdater
 
             $this->setVersion('3.1.0');
         }
+
+        $this->skip('3.1.', '3.2.0');
     }
 }


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/TAO-8853 

The goal of this development is to create a command which will export delivery assembly package with private files encrypted with symmetric encryption.

To test run a command: `php index.php 'oat\taoEncryption\scripts\tools\DeliveryAssembly\ExportEncryptedAssembly' -uri {DELIVERY_URI} -alg {ENCRYPTION_ALGORITHM} -key {ENCRYPTION_KEY} -out {OUTPUT_FILE.zip}`

For encryption algorithm better use `AES` which is used by default to encrypt/decrypt delivery files.
Encryption key - content of `user_application.key` file