### PR TITLE
TTD-18 Tests extends from `generis\test\TestCase`. All mock objects e…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'TAO encryption',
     'description' => 'TAO encryption',
     'license' => 'GPL-2.0',
-    'version' => '3.2.2',
+    'version' => '3.3.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=17.7.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -194,6 +194,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('3.2.1');
         }
 
-        $this->skip('3.2.1', '3.2.2');
+        $this->skip('3.2.1', '3.3.0');
     }
 }

--- a/test/Service/DeliveryLog/DecryptDeliveryLogFormatterServiceTest.php
+++ b/test/Service/DeliveryLog/DecryptDeliveryLogFormatterServiceTest.php
@@ -21,8 +21,9 @@ namespace oat\taoEncryption\Test\Service\DeliveryLog;
 
 use oat\taoEncryption\Service\DeliveryLog\DecryptDeliveryLogFormatterService;
 use oat\taoEncryption\Service\EncryptionSymmetricService;
+use oat\generis\test\TestCase;
 
-class DecryptDeliveryLogFormatterServiceTest extends \PHPUnit_Framework_TestCase
+class DecryptDeliveryLogFormatterServiceTest extends TestCase
 {
     public function testFormat()
     {

--- a/test/Service/DeliveryMonitoring/EncryptedMonitoringServiceTest.php
+++ b/test/Service/DeliveryMonitoring/EncryptedMonitoringServiceTest.php
@@ -25,8 +25,9 @@ use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
 use oat\taoEncryption\Service\DeliveryMonitoring\EncryptedMonitoringService;
 use oat\taoProctoring\model\monitorCache\DeliveryMonitoringData;
+use oat\generis\test\TestCase;
 
-class EncryptedMonitoringServiceTest extends \PHPUnit_Framework_TestCase
+class EncryptedMonitoringServiceTest extends TestCase
 {
     public function testMonitoring()
     {

--- a/test/Service/EncryptionSymmetricServiceTest.php
+++ b/test/Service/EncryptionSymmetricServiceTest.php
@@ -23,8 +23,9 @@ use oat\taoEncryption\Service\Algorithm\AlgorithmSymmetricService;
 use oat\taoEncryption\Service\EncryptionSymmetricService;
 use oat\taoEncryption\Service\KeyProvider\SymmetricKeyProviderService;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use oat\generis\test\TestCase;
 
-class EncryptionSymmetricServiceTest extends \PHPUnit_Framework_TestCase
+class EncryptionSymmetricServiceTest extends TestCase
 {
     public function testFlow()
     {

--- a/test/Service/FileSystem/EncryptionFlyWrapperTest.php
+++ b/test/Service/FileSystem/EncryptionFlyWrapperTest.php
@@ -25,8 +25,9 @@ use oat\taoEncryption\Service\EncryptionSymmetricService;
 use oat\taoEncryption\Service\FileSystem\EncryptionFlyWrapper;
 use oat\taoEncryption\Service\KeyProvider\FileKeyProviderService;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use oat\generis\test\TestCase;
 
-class EncryptionFlyWrapperTest extends \PHPUnit_Framework_TestCase
+class EncryptionFlyWrapperTest extends TestCase
 {
     public function testGetAdapter()
     {

--- a/test/Service/KeyProvider/DummyKeyProviderTest.php
+++ b/test/Service/KeyProvider/DummyKeyProviderTest.php
@@ -22,8 +22,9 @@ namespace oat\taoEncryption\Test\Service\KeyProvider;
 
 use oat\taoEncryption\Model\Key;
 use oat\taoEncryption\Service\KeyProvider\DummyKeyProvider;
+use oat\generis\test\TestCase;
 
-class DummyKeyProviderTest extends \PHPUnit_Framework_TestCase
+class DummyKeyProviderTest extends TestCase
 {
     public function testGetKey()
     {

--- a/test/Service/KeyProvider/FileKeyProviderServiceTest.php
+++ b/test/Service/KeyProvider/FileKeyProviderServiceTest.php
@@ -28,8 +28,10 @@ use oat\taoEncryption\Model\Key;
 use oat\taoEncryption\Service\KeyProvider\FileKeyProviderService;
 use oat\taoEncryption\Service\Session\EncryptedUser;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use oat\generis\test\TestCase;
+use oat\generis\test\MockObject;
 
-class FileKeyProviderServiceTest extends \PHPUnit_Framework_TestCase
+class FileKeyProviderServiceTest extends TestCase
 {
 
     public function testGetKey()
@@ -136,7 +138,7 @@ class FileKeyProviderServiceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function getService()
     {

--- a/test/Service/KeyProvider/KeyProviderClientTest.php
+++ b/test/Service/KeyProvider/KeyProviderClientTest.php
@@ -24,8 +24,9 @@ namespace oat\taoEncryption\Test\Service\KeyProvider;
 use oat\taoEncryption\Service\KeyProvider\KeyProviderClient;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use oat\generis\test\TestCase;
 
-class KeyProviderClientTest extends \PHPUnit_Framework_TestCase
+class KeyProviderClientTest extends TestCase
 {
 
     public function testUpdatePublicKey()

--- a/test/Service/KeyProvider/SimpleKeyProviderServiceTest.php
+++ b/test/Service/KeyProvider/SimpleKeyProviderServiceTest.php
@@ -21,8 +21,9 @@ namespace oat\taoEncryption\Test\Service\KeyProvider;
 
 use oat\taoEncryption\Model\Key;
 use oat\taoEncryption\Service\KeyProvider\SimpleKeyProviderService;
+use oat\generis\test\TestCase;
 
-class SimpleKeyProviderServiceTest extends \PHPUnit_Framework_TestCase
+class SimpleKeyProviderServiceTest extends TestCase
 {
     public function testGetKey()
     {

--- a/test/Service/LtiConsumer/EncryptLtiConsumerFormatterServiceTest.php
+++ b/test/Service/LtiConsumer/EncryptLtiConsumerFormatterServiceTest.php
@@ -26,8 +26,9 @@ use oat\taoEncryption\Service\KeyProvider\SimpleKeyProviderService;
 use oat\taoEncryption\Service\LtiConsumer\EncryptedLtiConsumer;
 use oat\taoEncryption\Service\LtiConsumer\EncryptLtiConsumerFormatterService;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use oat\generis\test\TestCase;
 
-class EncryptLtiConsumerFormatterServiceTest extends \PHPUnit_Framework_TestCase
+class EncryptLtiConsumerFormatterServiceTest extends TestCase
 {
     /**
      * @throws \Exception

--- a/test/Service/Result/DecryptResultServiceTest.php
+++ b/test/Service/Result/DecryptResultServiceTest.php
@@ -35,6 +35,7 @@ use oat\taoSync\model\TestSession\SyncTestSessionServiceInterface;
 use taoResultServer_models_classes_Variable;
 use taoResultServer_models_classes_WritableResultStorage;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use oat\generis\test\MockObject;
 
 class DecryptResultServiceTest extends TestCase
 {
@@ -104,7 +105,7 @@ class DecryptResultServiceTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockDeliveryExecution()
     {
@@ -175,7 +176,7 @@ class DecryptResultServiceTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockPersistence()
     {

--- a/test/Service/Result/SyncEncryptedResultServiceTest.php
+++ b/test/Service/Result/SyncEncryptedResultServiceTest.php
@@ -30,16 +30,17 @@ use oat\taoEncryption\Service\EncryptionServiceInterface;
 use oat\taoEncryption\Service\Mapper\MapperClientUserIdToCentralUserIdInterface;
 use oat\taoEncryption\Service\Result\SyncEncryptedResultService;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use oat\generis\test\MockObject;
 
 class SyncEncryptedResultServiceTest extends TestCase
 {
     /**
-     * @var common_persistence_Manager|\PHPUnit_Framework_MockObject_MockObject
+     * @var common_persistence_Manager|MockObject
      */
     private $persistenceMock;
 
     /**
-     * @var EncryptionServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var EncryptionServiceInterface|MockObject
      */
     private $encryptionServiceMock;
 
@@ -102,7 +103,7 @@ class SyncEncryptedResultServiceTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockResource()
     {
@@ -179,7 +180,7 @@ class SyncEncryptedResultServiceTest extends TestCase
     }
 
     /**
-     * @return common_persistence_Manager|\PHPUnit_Framework_MockObject_MockObject
+     * @return common_persistence_Manager|MockObject
      */
     protected function mockPersistence()
     {
@@ -205,7 +206,7 @@ class SyncEncryptedResultServiceTest extends TestCase
     }
 
     /**
-     * @return EncryptionServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @return EncryptionServiceInterface|MockObject
      */
     protected function mockEncryptionService()
     {

--- a/test/Service/Session/EncryptedUserTest.php
+++ b/test/Service/Session/EncryptedUserTest.php
@@ -25,8 +25,10 @@ use oat\oatbox\service\ServiceManager;
 use oat\taoEncryption\Service\EncryptionSymmetricService;
 use oat\taoEncryption\Service\KeyProvider\SimpleKeyProviderService;
 use oat\taoEncryption\Service\Session\EncryptedUser;
+use oat\generis\test\TestCase;
+use oat\generis\test\MockObject;
 
-class EncryptedUserTest extends \PHPUnit_Framework_TestCase
+class EncryptedUserTest extends TestCase
 {
 
     /**
@@ -45,7 +47,7 @@ class EncryptedUserTest extends \PHPUnit_Framework_TestCase
     /**
      * @param $userIdentifier
      * @param $hashForEncryption
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      * @throws \Exception
      */
     protected function mockCommonUser($userIdentifier, $hashForEncryption)

--- a/test/Service/SessionState/EncryptedStateStorageTest.php
+++ b/test/Service/SessionState/EncryptedStateStorageTest.php
@@ -27,8 +27,10 @@ use oat\taoEncryption\Service\KeyProvider\SimpleKeyProviderService;
 use oat\taoEncryption\Service\Session\EncryptedUser;
 use oat\taoEncryption\Service\SessionState\EncryptedStateStorage;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use oat\generis\test\TestCase;
+use oat\generis\test\MockObject;
 
-class EncryptedStateStorageTest extends \PHPUnit_Framework_TestCase
+class EncryptedStateStorageTest extends TestCase
 {
     /**
      * @throws \Exception
@@ -63,7 +65,7 @@ class EncryptedStateStorageTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @param bool $encrypted
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     public function getService($encrypted = true)
     {

--- a/test/Service/Sync/EncryptRdfDeliverySyncFormatterTest.php
+++ b/test/Service/Sync/EncryptRdfDeliverySyncFormatterTest.php
@@ -23,8 +23,9 @@ use oat\taoEncryption\Rdf\EncryptedDeliveryRdf;
 use oat\taoEncryption\Service\KeyProvider\FileKeyProviderService;
 use oat\taoEncryption\Service\Sync\EncryptRdfDeliverySyncFormatter;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use oat\generis\test\TestCase;
 
-class EncryptRdfDeliverySyncFormatterTest extends \PHPUnit_Framework_TestCase
+class EncryptRdfDeliverySyncFormatterTest extends TestCase
 {
     /**
      * @throws \common_exception_Error

--- a/test/Service/Sync/EncryptUserSyncFormatterTest.php
+++ b/test/Service/Sync/EncryptUserSyncFormatterTest.php
@@ -25,8 +25,9 @@ use oat\generis\model\OntologyRdfs;
 use oat\taoEncryption\Rdf\EncryptedUserRdf;
 use oat\taoEncryption\Service\EncryptionSymmetricService;
 use oat\taoEncryption\Service\Sync\EncryptUserSyncFormatter;
+use oat\generis\test\TestCase;
 
-class EncryptUserSyncFormatterTest extends \PHPUnit_Framework_TestCase
+class EncryptUserSyncFormatterTest extends TestCase
 {
     protected $encryptString;
 

--- a/test/Service/User/EncryptedUserFactoryServiceTest.php
+++ b/test/Service/User/EncryptedUserFactoryServiceTest.php
@@ -23,8 +23,10 @@ namespace oat\taoEncryption\Test\Service\User;
 use core_kernel_classes_Resource;
 use oat\taoEncryption\Service\Session\EncryptedUser;
 use oat\taoEncryption\Service\User\EncryptedUserFactoryService;
+use oat\generis\test\TestCase;
+use oat\generis\test\MockObject;
 
-class EncryptedUserFactoryServiceTest extends \PHPUnit_Framework_TestCase
+class EncryptedUserFactoryServiceTest extends TestCase
 {
 
     /**
@@ -76,7 +78,7 @@ class EncryptedUserFactoryServiceTest extends \PHPUnit_Framework_TestCase
 
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockResource()
     {

--- a/test/Service/User/UserHandlerKeysTest.php
+++ b/test/Service/User/UserHandlerKeysTest.php
@@ -25,8 +25,9 @@ use oat\taoEncryption\Service\KeyProvider\FileKeyProviderService;
 use oat\taoEncryption\Service\KeyProvider\SimpleKeyProviderService;
 use oat\taoEncryption\Service\User\UserHandlerKeys;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use oat\generis\test\TestCase;
 
-class UserHandlerKeysTest extends \PHPUnit_Framework_TestCase
+class UserHandlerKeysTest extends TestCase
 {
 
     public function testGenerateUserKey()


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TTD-18
All tests extends `generis\test\TestCase` instead of `\PHPUnit_Framework_TestCase`
All Mock objects instances of `generis\test\MockObject` instead of `\PHPUnit_Framework_MockObject_MockObject`. Mocks was used only in phpdoc.
Possible way to test:
1) run unit tests.
2) update code.
3) run unit tests again. result should be the same as in 1.