### PR TITLE
Feature/TAO-10019/Remove PHPUnit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,6 @@
         "tao-extension-name": "taoEncryption"
     },
     "minimum-stability" : "dev",
-    "require-dev":{
-        "phpunit/phpunit": "6.5.0"
-    },
     "require": {
         "php" : ">=5.5",
         "phpseclib/phpseclib": "~2.0.0"

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'TAO encryption',
     'description' => 'TAO encryption',
     'license' => 'GPL-2.0',
-    'version' => '5.0.0',
+    'version' => '5.0.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=17.7.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -194,6 +194,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('3.2.1');
         }
 
-        $this->skip('3.2.1', '5.0.0');
+        $this->skip('3.2.1', '5.0.1');
     }
 }


### PR DESCRIPTION
Related to: [https://oat-sa.atlassian.net/browse/TAO-10019](https://oat-sa.atlassian.net/browse/TAO-10019)

Remove PHPUnit dependency from the composer.json file:
- **require-dev** section was removed from the composer.json file;
- the version number was increased from 5.0.0 to 5.0.1.