### PR TITLE
fix: changing the parent class for the two commited services

### DIFF
--- a/model/Service/DeliveryMonitoring/EncryptedLtiMonitoringService.php
+++ b/model/Service/DeliveryMonitoring/EncryptedLtiMonitoringService.php
@@ -24,9 +24,9 @@ use oat\taoEncryption\Service\EncryptionSymmetricService;
 use oat\taoEncryption\Service\KeyProvider\SimpleKeyProviderService;
 use oat\taoEncryption\Service\Session\EncryptedLtiUser;
 use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
-use oat\taoProctoring\model\monitorCache\implementation\MonitorCacheService;
+use oat\taoProctoring\model\repository\MonitoringRepository;
 
-class EncryptedLtiMonitoringService extends MonitorCacheService
+class EncryptedLtiMonitoringService extends MonitoringRepository
 {
     /**
      * @param array $criteria
@@ -38,9 +38,9 @@ class EncryptedLtiMonitoringService extends MonitorCacheService
      * @throws \core_kernel_classes_EmptyProperty
      * @throws \oat\taoLti\models\classes\LtiVariableMissingException
      */
-    public function find(array $criteria = [], array $options = [], $together = false)
+    public function find(array $criteria = [], array $options = []): array
     {
-        $result = parent::find($criteria, $options, $together);
+        $result = parent::find($criteria, $options);
 
         foreach ($result as &$deliveryMonitoringData) {
             $isObject = is_object($deliveryMonitoringData);

--- a/model/Service/DeliveryMonitoring/EncryptedMonitoringService.php
+++ b/model/Service/DeliveryMonitoring/EncryptedMonitoringService.php
@@ -21,9 +21,9 @@
 namespace oat\taoEncryption\Service\DeliveryMonitoring;
 
 use oat\generis\model\GenerisRdf;
-use oat\taoProctoring\model\monitorCache\implementation\MonitorCacheService;
+use oat\taoProctoring\model\repository\MonitoringRepository;
 
-class EncryptedMonitoringService extends MonitorCacheService
+class EncryptedMonitoringService extends MonitoringRepository
 {
     const TEST_TAKER_LOGIN = 'test_taker_login';
     /**


### PR DESCRIPTION
The reason to have this PR is to fix the problem when
a) launching downstream sync on the DEPP VM;
b) launching the test on the DEPP VM;

To fix those problems, it was decided to updated both committed implementations, to make sure that they are up-to-date with latest taoProctoring changes. In fact all the discrepancy at the moment is because both those implementations are extending deprecated service, which still tries to get data from `kv_delivery_monitoring` while there is no such table in latest taoProctoring releases anymore.